### PR TITLE
Use ccache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ccache
     tags:
       - v*brim*
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ccache
     tags:
       - v*brim*
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,17 @@ jobs:
         sed "/typedef ADDRESS_FAMILY sa_family_t/d" "C:\Program Files (x86)\maxminddb\include\maxminddb.h.bak" > "C:\Program Files (x86)\maxminddb\include\maxminddb.h"
       shell: cmd
 
+    - uses: actions/cache@v3
+      with:
+        path: ${{runner.temp}}/.ccache
+        key: ${{ runner.os }}-ccache
+
     - name: Build Zeek (Windows)
       if: startsWith(matrix.platform, 'windows-')
       run: |
         choco install -y --no-progress conan --version=1.58.0
         choco install -y --no-progress winflexbison3
+        choco install -y --no-progress ccache
         call refreshenv
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
         mkdir zeek-src\build
@@ -70,14 +76,18 @@ jobs:
         cmake.exe --install .
         cd
       shell: cmd
+      env:
+        CCACHE_DIR: ${{runner.temp}}/.ccache
+        CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        CMAKE_C_COMPILER_LAUNCHER=ccache
 
     - name: Install dependencies (Linux)
       if: startsWith(matrix.platform, 'ubuntu-')
-      run: sudo apt-get -y install cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
+      run: sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
-      run: brew install cmake swig openssl bison flex libmaxminddb
+      run: brew install ccache cmake swig openssl bison flex libmaxminddb
 
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1
@@ -91,6 +101,10 @@ jobs:
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek
+      env:
+        CCACHE_DIR: ${{runner.temp}}/.ccache
+        CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        CMAKE_C_COMPILER_LAUNCHER=ccache
 
     - name: Finish packaging artifact
       run: ./release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,8 @@ jobs:
       shell: cmd
       env:
         CCACHE_DIR: ${{runner.temp}}/.ccache
-        CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        CMAKE_C_COMPILER_LAUNCHER=ccache
+        CMAKE_CXX_COMPILER_LAUNCHER: ccache
+        CMAKE_C_COMPILER_LAUNCHER: ccache
 
     - name: Install dependencies (Linux)
       if: startsWith(matrix.platform, 'ubuntu-')
@@ -103,8 +103,8 @@ jobs:
         sudo strip /usr/local/zeek/bin/zeek
       env:
         CCACHE_DIR: ${{runner.temp}}/.ccache
-        CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        CMAKE_C_COMPILER_LAUNCHER=ccache
+        CMAKE_CXX_COMPILER_LAUNCHER: ccache
+        CMAKE_C_COMPILER_LAUNCHER: ccache
 
     - name: Finish packaging artifact
       run: ./release.sh


### PR DESCRIPTION
On the advice of @nwt I've brought over relevant stuff from https://github.com/brimdata/zeek to leverage ccache in hopes of speeding up build times. While build times on these Actions runners are variable, the delta across back-to-back runs does show it having the intended benefit.

The comparative times for the "Build Zeek" step on each OS:

**Cold baseline** - https://github.com/brimdata/build-zeek/actions/runs/7424173966/attempts/1

|**OS**|**Build time**|
|-|-|
|macOS|25m 2s|
|Linux|19m 36s|
|Windows|21m 30s|

**Warm cache** - https://github.com/brimdata/build-zeek/actions/runs/7424173966

|**OS**|**Build time**|
|-|-|
|macOS|4m 40s|
|Linux|53s|
|Windows|3m 55s|
