### PR TITLE
Static libraries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - static-openssl
     tags:
       - v*brim*
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - static-libs
     tags:
       - v*brim*
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
         sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
-        echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
+        echo "extra_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: on_linux
 
     - name: Install dependencies (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,8 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.on_linux.outputs.extra_config }}
+        [ $(uname) = Linux ] && linux_flags='-D ZLIB_USE_STATIC_LIBS=TRUE'
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE $linux_flags
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
         # Removing shared objects to force static linking.
         sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
-        echo "extra_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: on_linux
 
     - name: Install dependencies (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - static-openssl
+      - static-libs
     tags:
       - v*brim*
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
-        sudo rm /usr/lib/x86_64-linux-gnu/libpcap*.so* /usr/lib/x86_64-linux-gnu/libmaxmind*.so*
+        sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
         echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: linux
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [macos-12, ubuntu-20.04, windows-2019]
+        platform: [macos-12]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -88,7 +88,7 @@ jobs:
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
-      run: brew install ccache cmake swig openssl bison flex libmaxminddb zlib
+      run: brew install ccache cmake swig openssl bison flex libmaxminddb
 
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1
@@ -98,7 +98,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON -D ZLIB_ROOT=/usr/local/Cellar/zlib/1.3/lib
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
+        # Removing shared objects to force static linking.
         sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
         echo "extra_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: on_linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
-        sudo rm /usr/lib/x86_64-linux-gnu/libpcap*.so* /usr/lib/x86_64-linux-gnu/libmaxmind*.so*
-        echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
-      id: linux
+        sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* -o -name libz.so\* \) -delete
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
@@ -102,7 +100,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.linux.outputs.extra_linux_config }}
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
-        sudo rm /usr/lib/x86_64-linux-gnu/libpcap.so /usr/lib/x86_64-linux-gnu/libpcap.so.0.8 /usr/lib/x86_64-linux-gnu/libpcap.so.1.9.1
+        sudo rm /usr/lib/x86_64-linux-gnu/libpcap*.so* /usr/lib/x86_64-linux-gnu/libmaxmind*.so*
         echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: linux
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [macos-12]
+        platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -98,7 +98,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON -D ZLIB_ROOT=/usr/local/Cellar/zlib/1.3/lib
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
         # Removing shared objects to force static linking.
         sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
-      id: on_linux
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,9 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
-        sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* -o -name libz.so\* \) -delete
+        sudo rm /usr/lib/x86_64-linux-gnu/libpcap*.so* /usr/lib/x86_64-linux-gnu/libmaxmind*.so*
+        echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
+      id: linux
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
@@ -100,7 +102,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.linux.outputs.extra_linux_config }}
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [ubuntu-20.04]
+        platform: [macos-12, ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -84,7 +84,10 @@ jobs:
 
     - name: Install dependencies (Linux)
       if: startsWith(matrix.platform, 'ubuntu-')
-      run: sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
+      run: |
+        sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
+        echo 'extra_linux_config="-D ZLIB_USE_STATIC_LIBS=ON"' >> $GITHUB_OUTPUT
+      id: linux
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
@@ -98,7 +101,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE -D ZLIB_USE_STATIC_LIBS=ON
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.linux.outputs.extra_linux_config }}
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
-      run: brew install ccache cmake swig openssl bison flex libmaxminddb
+      run: brew install ccache cmake swig openssl bison flex libmaxminddb zlib
 
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
+        sudo rm /usr/lib/x86_64-linux-gnu/libpcap.so /usr/lib/x86_64-linux-gnu/libpcap.so.0.8 /usr/lib/x86_64-linux-gnu/libpcap.so.1.9.1
         echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: linux
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
         sudo find /usr/lib \( -name libpcap.so\* -o -name libmaxminddb.so\* \) -delete
         echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
-      id: linux
+      id: on_linux
 
     - name: Install dependencies (macOS)
       if: startsWith(matrix.platform, 'macos-')
@@ -102,7 +102,7 @@ jobs:
       if: "!startsWith(matrix.platform, 'windows-')"
       run: |
         cd zeek-src
-        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.linux.outputs.extra_linux_config }}
+        ./configure --binary-package --enable-static-broker --enable-static-binpac --disable-spicy --disable-af-packet --disable-zeekctl --disable-python --disable-broker-tests --disable-auxtools --disable-archiver --osx-min-version=12 -D OPENSSL_USE_STATIC_LIBS=TRUE ${{ steps.on_linux.outputs.extra_config }}
         make -j${{ steps.cpu-cores.outputs.count }}
         sudo make install
         sudo strip /usr/local/zeek/bin/zeek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu-')
       run: |
         sudo apt-get -y install ccache cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev python3-setuptools swig zlib1g-dev zip libmaxminddb-dev
-        echo 'extra_linux_config="-D ZLIB_USE_STATIC_LIBS=ON"' >> $GITHUB_OUTPUT
+        echo "extra_linux_config=-D ZLIB_USE_STATIC_LIBS=ON" >> $GITHUB_OUTPUT
       id: linux
 
     - name: Install dependencies (macOS)


### PR DESCRIPTION
When inspecting a previous artifact built from this repo, @nwt spotted some dynamic library dependencies that had not been there in our [v3.2.1-brim10](https://github.com/brimdata/zeek/releases/tag/v3.2.1-brim10) artifact that's been in use for years. To minimize the chance of new issues among users, this PR makes makes sure we link to the static libraries in all those cases.

Using the latest artifact built from this branch, proof is provided below that compares vs. [v3.2.1-brim10](https://github.com/brimdata/zeek/releases/tag/v3.2.1-brim10).

## macOS

tl;dr - The dynamic library dependencies are the same as before.

```
10:28:35-phil@wpm:~/Downloads/zeek-v3.2.1-brim10.darwin-amd64/zeek/bin$ otool -L zeek | sort
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 904.4.0)
	/usr/lib/libpcap.A.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)

11:13:59-phil@wpm:~/Downloads/zeek-7fbbf89.darwin-amd64/zeek/bin$ otool -L zeek | sort
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.36.0)
	/usr/lib/libpcap.A.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
```


## Windows

tl;dr - [`PSAPI.DLL`](https://learn.microsoft.com/en-us/windows/win32/psapi/process-status-helper) is no longer a dependency. [`CRYPT32.dll`](https://learn.microsoft.com/en-us/windows/win32/seccrypto/crypt32-dll-versions) is a new dependency and [appears legit](https://docs.zeek.org/en/master/scripts/policy/frameworks/software/windows-version-detection.zeek.html).

```
C:\Users\Phil\Downloads\zeek-v3.2.1-brim10.windows-amd64\zeek\bin>"\Program Files\Git\usr\bin\ldd.exe" zeek.exe | sort
        ADVAPI32.dll => /c/WINDOWS/System32/ADVAPI32.dll (0x7ffc6b760000)
        GDI32.dll => /c/WINDOWS/System32/GDI32.dll (0x7ffc6c480000)
        gdi32full.dll => /c/WINDOWS/System32/gdi32full.dll (0x7ffc6a8b0000)
        IPHLPAPI.DLL => /c/WINDOWS/SYSTEM32/IPHLPAPI.DLL (0x7ffc69cf0000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7ffc6c550000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7ffc6aba0000)
        msvcp_win.dll => /c/WINDOWS/System32/msvcp_win.dll (0x7ffc6a9d0000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7ffc6b4c0000)
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7ffc6d1d0000)
        PSAPI.DLL => /c/WINDOWS/System32/PSAPI.DLL (0x7ffc6cc20000)
        RPCRT4.dll => /c/WINDOWS/System32/RPCRT4.dll (0x7ffc6cc30000)
        sechost.dll => /c/WINDOWS/System32/sechost.dll (0x7ffc6c4b0000)
        SHLWAPI.dll => /c/WINDOWS/System32/SHLWAPI.dll (0x7ffc6b560000)
        ucrtbase.dll => /c/WINDOWS/System32/ucrtbase.dll (0x7ffc6b000000)
        USER32.dll => /c/WINDOWS/System32/USER32.dll (0x7ffc6c610000)
        win32u.dll => /c/WINDOWS/System32/win32u.dll (0x7ffc6b100000)
        WS2_32.dll => /c/WINDOWS/System32/WS2_32.dll (0x7ffc6cdc0000)

C:\Users\Phil\Downloads\windows-2019\zeek-7fbbf89.windows-amd64\zeek\bin>"\Program Files\Git\usr\bin\ldd.exe" zeek.exe | sort
        ADVAPI32.dll => /c/WINDOWS/System32/ADVAPI32.dll (0x7ffc6b760000)
        CRYPT32.dll => /c/WINDOWS/System32/CRYPT32.dll (0x7ffc6aea0000)
        GDI32.dll => /c/WINDOWS/System32/GDI32.dll (0x7ffc6c480000)
        gdi32full.dll => /c/WINDOWS/System32/gdi32full.dll (0x7ffc6a8b0000)
        IPHLPAPI.DLL => /c/WINDOWS/SYSTEM32/IPHLPAPI.DLL (0x7ffc69cf0000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7ffc6c550000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7ffc6aba0000)
        msvcp_win.dll => /c/WINDOWS/System32/msvcp_win.dll (0x7ffc6a9d0000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7ffc6b4c0000)
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7ffc6d1d0000)
        RPCRT4.dll => /c/WINDOWS/System32/RPCRT4.dll (0x7ffc6cc30000)
        sechost.dll => /c/WINDOWS/System32/sechost.dll (0x7ffc6c4b0000)
        SHLWAPI.dll => /c/WINDOWS/System32/SHLWAPI.dll (0x7ffc6b560000)
        ucrtbase.dll => /c/WINDOWS/System32/ucrtbase.dll (0x7ffc6b000000)
        USER32.dll => /c/WINDOWS/System32/USER32.dll (0x7ffc6c610000)
        win32u.dll => /c/WINDOWS/System32/win32u.dll (0x7ffc6b100000)
        WS2_32.dll => /c/WINDOWS/System32/WS2_32.dll (0x7ffc6cdc0000)        
```

## Linux

tl;dr - The dynamic library dependencies are the same as before.

```
phil@phil-VirtualBox:~/zeek-v3.2.1-brim10.linux-amd64/zeek/bin$ ldd zeek  | sort
	/lib64/ld-linux-x86-64.so.2 (0x00007fdce16e0000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdcdfc1e000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fdce015c000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fdcdfe10000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fdcdfe2b000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fdce0162000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fdcdff7a000)
	linux-vdso.so.1 (0x00007ffd056e1000)

phil@phil-VirtualBox:~/zeek-7fbbf89.linux-amd64/zeek/bin$ ldd zeek | sort
	/lib64/ld-linux-x86-64.so.2 (0x00007fdb2889d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdb26aec000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fdb2702a000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fdb26cde000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fdb26cf9000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fdb27030000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fdb26e48000)
	linux-vdso.so.1 (0x00007ffda3dcf000)
```
