### PR TITLE
Use libmaxminddb 1.9.0 and remove workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,19 +41,16 @@ jobs:
       if: startsWith(matrix.platform, 'windows-')
       run: go build -o zeekrunner.exe zeekrunner.go
 
-    # Includes workaround from https://github.com/maxmind/libmaxminddb/pull/334
     - name: Build libmaxminddb (Windows)
       if: startsWith(matrix.platform, 'windows-')
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        curl -L https://github.com/maxmind/libmaxminddb/releases/download/1.8.0/libmaxminddb-1.8.0.tar.gz | tar xzvf -
-        mkdir libmaxminddb-1.8.0\build
-        cd libmaxminddb-1.8.0\build
+        curl -L https://github.com/maxmind/libmaxminddb/releases/download/1.9.0/libmaxminddb-1.9.0.tar.gz | tar xzvf -
+        mkdir libmaxminddb-1.9.0\build
+        cd libmaxminddb-1.9.0\build
         cmake ..
         cmake --build .
         cmake --build . --target install
-        rename "C:\Program Files (x86)\maxminddb\include\maxminddb.h" maxminddb.h.bak
-        sed "/typedef ADDRESS_FAMILY sa_family_t/d" "C:\Program Files (x86)\maxminddb\include\maxminddb.h.bak" > "C:\Program Files (x86)\maxminddb\include\maxminddb.h"
       shell: cmd
 
     - uses: actions/cache@v3


### PR DESCRIPTION
I tested out a Zeek artifact build using this new libmaxminddb and the GeoIP info gets generated as always.

Closes #2