### PR TITLE
Add workaround for zeek/3534 on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Finish packaging artifact
       run: ./release.sh
-      shell: sh
+      shell: bash
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 case $(uname) in
     Darwin|Linux)
@@ -74,6 +74,11 @@ install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfd
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
 echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+
+# Work around https://github.com/zeek/zeek/issues/3534 on Windows
+[[ $(uname) =~ "NT" ]] &&
+  mv /usr/local/zeek/share/zeek/site/local.zeek /usr/local/zeek/share/zeek/site/local.zeek.orig &&
+  sed 's/^@load protocols\/ssh\/interesting-hostnames/#@load protocols\/ssh\/interesting-hostnames # https:\/\/github.com\/zeek\/zeek\/issues\/3534 workaround/; s/^@load frameworks\/files\/detect-MHR/#@load frameworks\/files\/detect-MHR # https:\/\/github.com\/zeek\/zeek\/issues\/3534 workaround/' /usr/local/zeek/share/zeek/site/local.zeek.orig > /usr/local/zeek/share/zeek/site/local.zeek
 
 #
 # Create zip file.

--- a/release.sh
+++ b/release.sh
@@ -77,8 +77,10 @@ echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/loca
 
 # Work around https://github.com/zeek/zeek/issues/3534 on Windows
 [[ $(uname) =~ "NT" ]] &&
-  mv /usr/local/zeek/share/zeek/site/local.zeek /usr/local/zeek/share/zeek/site/local.zeek.orig &&
-  sed 's/^@load protocols\/ssh\/interesting-hostnames/#@load protocols\/ssh\/interesting-hostnames # https:\/\/github.com\/zeek\/zeek\/issues\/3534 workaround/; s/^@load frameworks\/files\/detect-MHR/#@load frameworks\/files\/detect-MHR # https:\/\/github.com\/zeek\/zeek\/issues\/3534 workaround/' /usr/local/zeek/share/zeek/site/local.zeek.orig > /usr/local/zeek/share/zeek/site/local.zeek
+  sed -i \
+    -e 's|^@load protocols/ssh/interesting-hostnames|#\0 # https://github.com/zeek/zeek/issues/3534 workaround|' \
+    -e  's|^@load frameworks/files/detect-MHR|#\0 # https://github.com/zeek/zeek/issues/3534 workaround|' \
+    /usr/local/zeek/share/zeek/site/local.zeek
 
 #
 # Create zip file.

--- a/release.sh
+++ b/release.sh
@@ -79,7 +79,7 @@ echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/loca
 [[ $(uname) =~ "NT" ]] &&
   sed -i \
     -e 's|^@load protocols/ssh/interesting-hostnames|#\0 # https://github.com/zeek/zeek/issues/3534 workaround|' \
-    -e  's|^@load frameworks/files/detect-MHR|#\0 # https://github.com/zeek/zeek/issues/3534 workaround|' \
+    -e 's|^@load frameworks/files/detect-MHR|#\0 # https://github.com/zeek/zeek/issues/3534 workaround|' \
     /usr/local/zeek/share/zeek/site/local.zeek
 
 #


### PR DESCRIPTION
https://github.com/zeek/zeek/issues/3534 was the one open issue that was holding me back from packaging a Zeek v6 artifact with Zui. That's now spawned follow-on issue https://github.com/mheily/libkqueue/issues/155 and based on the lack of activity in that libkqueue repo I don't have much faith a fix is coming any time soon. Therefore it seems it's time to make a call on going ahead with shipping a Zeek v6 artifact that disables the packages that are known to trigger that segfault.

The changes in this branch comment out the `@load` of the two packages that trigger the bad code path as part of the bundling of the Windows artifact. I've made a test Zeek artifact [v6.2.0-brim-dev2](https://github.com/brimdata/build-zeek/releases/tag/v6.2.0-brim-dev2) based on that and referenced that in test Brimcap artifact [v1.6.0-alpha4](https://github.com/brimdata/brimcap/releases/tag/v1.6.0-alpha4) and then referenced that Brimcap artifact from the Zui dev build from Actions run https://github.com/brimdata/zui/actions/runs/7534518094. With that Zui I've confirmed that the wrccdc 2018 pcaps that formerly triggered the segfault can loaded into that Zui without error. I've also done side-by-side drags of the 4 GB "all.pcap" and confirmed we see the expected delta in `notice` events based on the disabling of the `detect-MHR` package in the Windows case.

## macOS

![image](https://github.com/brimdata/build-zeek/assets/5934157/23dc0091-9e08-461a-8b3f-14b185d347ee)

## Windows

![image](https://github.com/brimdata/build-zeek/assets/5934157/0e060cb9-032a-4339-993b-6cfa59358c61)
