### PR TITLE
Build from Zeek v6.0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: zeek/zeek
-        ref: v6.0.2
+        ref: v6.0.3
         fetch-depth: 1
         submodules: recursive
         path: zeek-src


### PR DESCRIPTION
Zeek [v6.0.3](https://github.com/zeek/zeek/releases/tag/v6.0.3) was just published today. It doesn't appear to have functional changes that will significantly affect Zui workflows. However, I'd like us to be good citizens in doing timely releases particularly when one of their releases has security fixes, such as this one does.

I've already created and smoke tested a Brimcap [v1.6.0-beta2](https://github.com/brimdata/brimcap/releases/tag/v1.6.0-beta2) pre-release artifact that uses a Zeek [v6.0.3-brim1](https://github.com/brimdata/build-zeek/releases/tag/v6.0.3-brim1) artifact made from this branch and I've loaded test pcaps in Zui successfully with it. See https://github.com/brimdata/zui/pull/2984.