### PR TITLE
Build from Zeek v6.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: zeek/zeek
-        ref: v6.0.3
+        ref: v6.2.0
         fetch-depth: 1
         submodules: recursive
         path: zeek-src
@@ -61,14 +61,13 @@ jobs:
     - name: Build Zeek (Windows)
       if: startsWith(matrix.platform, 'windows-')
       run: |
-        choco install -y --no-progress conan --version=1.58.0
         choco install -y --no-progress winflexbison3
         choco install -y --no-progress ccache
         call refreshenv
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
         mkdir zeek-src\build
         cd zeek-src\build
-        cmake.exe .. -DCMAKE_BUILD_TYPE=release -DENABLE_ZEEK_UNIT_TESTS=yes -D CMAKE_INSTALL_PREFIX="C:\Program Files\Git\usr\local\zeek" -DLibMMDB_INCLUDE_DIR="C:\Program Files (x86)\maxminddb\include" -DLibMMDB_LIBRARY="C:\Program Files (x86)\maxminddb\lib\maxminddb.lib" -G Ninja
+        cmake.exe .. -DCMAKE_BUILD_TYPE=release -DVCPKG_TARGET_TRIPLET="x64-windows-static" -DENABLE_ZEEK_UNIT_TESTS=yes -DCMAKE_INSTALL_PREFIX="C:\Program Files\Git\usr\local\zeek" -DLibMMDB_INCLUDE_DIR="C:\Program Files (x86)\maxminddb\include" -DLibMMDB_LIBRARY="C:\Program Files (x86)\maxminddb\lib\maxminddb.lib" -G Ninja
         cmake.exe --build .
         cmake.exe --install .
         cd


### PR DESCRIPTION
Zeek [v6.2.0](https://github.com/zeek/zeek/releases/tag/v6.2.0) was recently released. One change in particular I've been waiting to take advantage of in that release is the fix to https://github.com/zeek/broker/issues/316, which I originally reported separately with my own issue at https://github.com/zeek/zeek/issues/3532. I just now generated a Zeek artifact based on this branch in an [Actions run](https://github.com/brimdata/build-zeek/actions/runs/8382735809) and followed the repro steps from https://github.com/zeek/broker/issues/316 to verify that the issue is fixed. Beyond that, it'll just be good to have the latest Zeek bundled with our next set of Brimcap/Zui releases, which I hope to be putting together soon.

In addition to pointing at the new Zeek release tags, the build steps have been adjusted to reflect the changes in https://github.com/zeek/zeek/pull/3576, which I became aware of when doing early verifications of https://github.com/zeek/broker/issues/316 at the request of the Zeek dev team.