### PR TITLE
Enable ssl-log-ext

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,7 @@ $sudo pip3 install btest wheel
 install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
-cat << EOF | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+$sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek << EOF
 @load policy/protocols/conn/community-id-logging
 @load policy/protocols/ssl/ssl-log-ext
 EOF

--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,10 @@ $sudo pip3 install btest wheel
 install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
-echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+cat << EOF | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+@load policy/protocols/conn/community-id-logging
+@load policy/protocols/ssl/ssl-log-ext
+EOF
 
 # Work around https://github.com/zeek/zeek/issues/3534 on Windows
 [[ $(uname) =~ "NT" ]] &&


### PR DESCRIPTION
About 1.5 years ago, a community user inquired as described in #12 about wanting to see the Client Cipher suites in the Zeek SSL logs. At the time we were stalled on being able to make new Zeek builds, but now that we're actively making them again, this PR proposes this additional detail now be included the logs generated from pcaps by enabling Zeek's [ssl-log-ext](https://docs.zeek.org/en/master/scripts/policy/protocols/ssl/ssl-log-ext.zeek.html) config.

That same Zeek page makes the argument that it's disabled by default because it "significantly expands the log" and "is probably not interesting for a majority of people". However, the community user that spawned the inquiry seemed pretty passionate about finding this detail useful. As the current direction of the Zed/Zui projects is to be broadly applicable to all kinds of data, I'm inclined to defer to the instincts of the security experts in the community to help shape the "sensible defaults" of the pcap analyzers that are still included with the tools.

To quantify the change, running [this wrccdc pcap](https://archive.wrccdc.org/pcaps/2018/wrccdc.2018-03-23.010014000000000.pcap.gz) through the [v6.2.0-brim1](https://github.com/brimdata/build-zeek/releases/tag/v6.2.0-brim1) artifact as a baseline and then the one from this branch, the size of the Zeek TSV `ssl.log` increases from 144 KB to 276 KB and the run time to process the pcap on my Macbook didn't change significantly, 21.348 sec increasing to 21.691 sec. Storage is cheap and it seems easier for users that don't need this detail to ignore it than for users that need it to be stuck going off to build a [Brimcap config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config) with their own custom changes like this, so to me that further justifies just flipping the default.

Here's an example of an SSL record before the change:

```
{
    _path: "ssl",
    ts: 2018-03-23T19:58:22.804636Z,
    uid: "CoGhnT32tYkg7ZLaYh",
    id: {
        orig_h: 10.47.2.156,
        orig_p: 49285 (port=uint16),
        resp_h: 52.85.83.187,
        resp_p: 443 (port)
    },
    version: "TLSv12",
    cipher: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
    curve: "secp256r1",
    server_name: "activity-stream-icons.services.mozilla.com",
    resumed: false,
    last_alert: null (string),
    next_protocol: "h2",
    established: true,
    ssl_history: "CsxuknGIti",
    cert_chain_fps: [
        "98fb1f149e3d366db42b235da177ef6c438375135f5f12dfeac41b7671b20611",
        "154c433c491929c5ef686e838e323664a00e6a0d822ccc958fb4dab03e49a08f"
    ],
    client_cert_chain_fps: [] ([string]),
    sni_matches_cert: true,
    validation_status: "ok",
    ja3: "0ffee3ba8e615ad22535e7f771690a28",
    ja3s: "76cc3e2d3028143b23ec18e27dbd7ca9"
}
```

Here it is with the additional detail.

```
{
    _path: "ssl",
    ts: 2018-03-23T19:58:22.804636Z,
    uid: "CwAEAF2q5j7krWPrE2",
    id: {
        orig_h: 10.47.2.156,
        orig_p: 49285 (port=uint16),
        resp_h: 52.85.83.187,
        resp_p: 443 (port)
    },
    version: "TLSv12",
    cipher: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
    curve: "secp256r1",
    server_name: "activity-stream-icons.services.mozilla.com",
    resumed: false,
    last_alert: null (string),
    next_protocol: "h2",
    established: true,
    ssl_history: "CsxuknGIti",
    cert_chain_fps: [
        "98fb1f149e3d366db42b235da177ef6c438375135f5f12dfeac41b7671b20611",
        "154c433c491929c5ef686e838e323664a00e6a0d822ccc958fb4dab03e49a08f"
    ],
    client_cert_chain_fps: [] ([string]),
    sni_matches_cert: true,
    validation_status: "ok",
    ja3: "0ffee3ba8e615ad22535e7f771690a28",
    ja3s: "76cc3e2d3028143b23ec18e27dbd7ca9",
    server_version: 771 (uint64),
    client_version: 771 (uint64),
    client_ciphers: [
        49195 (uint64),
        49199 (uint64),
        52393 (uint64),
        52392 (uint64),
        49196 (uint64),
        49200 (uint64),
        49162 (uint64),
        49161 (uint64),
        49171 (uint64),
        49172 (uint64),
        51 (uint64),
        57 (uint64),
        47 (uint64),
        53 (uint64),
        10 (uint64)
    ],
    ssl_client_exts: [
        0 (uint64),
        23 (uint64),
        65281 (uint64),
        10 (uint64),
        11 (uint64),
        35 (uint64),
        16 (uint64),
        5 (uint64),
        13 (uint64)
    ],
    ssl_server_exts: [
        0 (uint64),
        65281 (uint64),
        11 (uint64),
        35 (uint64),
        5 (uint64),
        16 (uint64)
    ],
    ticket_lifetime_hint: 10800 (uint64),
    dh_param_size: null (uint64),
    point_formats: [
        0 (uint64)
    ],
    client_curves: [
        29 (uint64),
        23 (uint64),
        24 (uint64),
        25 (uint64)
    ],
    orig_alpn: [
        "h2",
        "http/1.1"
    ],
    client_supported_versions: null ([uint64]),
    server_supported_version: null (uint64),
    psk_key_exchange_modes: null ([uint64]),
    client_key_share_groups: null ([uint64]),
    server_key_share_group: null (uint64),
    client_comp_methods: [
        0 (uint64)
    ],
    sigalgs: [
        3 (uint64),
        3 (uint64),
        3 (uint64),
        4 (uint64),
        5 (uint64),
        6 (uint64),
        1 (uint64),
        1 (uint64),
        1 (uint64),
        3 (uint64),
        1 (uint64)
    ],
    hashalgs: [
        4 (uint64),
        5 (uint64),
        6 (uint64),
        8 (uint64),
        8 (uint64),
        8 (uint64),
        4 (uint64),
        5 (uint64),
        6 (uint64),
        2 (uint64),
        2 (uint64)
    ]
}
```

Closes #12 
