### PR TITLE
Add geolocation data to notice logs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,15 @@ $sudo pip3 install btest wheel
 install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
-echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+cat << 'EOF' | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek
+@load policy/protocols/conn/community-id-logging
+
+# Add geolocation data to notice logs
+hook Notice::policy(n: Notice::Info) &priority=10
+        {
+        add n$actions[Notice::ACTION_ADD_GEODATA];
+        }
+EOF
 
 # Work around https://github.com/zeek/zeek/issues/3534 on Windows
 [[ $(uname) =~ "NT" ]] &&


### PR DESCRIPTION
The changes in this PR will populate the `remote_location` record in all `notice` events with geolocation data that's available for the IP address that's perceived to be the "remote" side of the connection that generated the event (see [docs](https://docs.zeek.org/en/master/scripts/base/frameworks/notice/actions/add-geodata.zeek.html) for more detail). Thanks to @JustinAzoff from the Zeek team that offered the tip in https://github.com/zeek/zeek/issues/3674 for how we can accomplish this for all flavors of `notice` event while continuing to consolidate all our config changes in `local.zeek`.

I've tested using an artifact from [this actions run](https://github.com/brimdata/build-zeek/actions/runs/8604886448) and the test data in [repro2.pcap.gz](https://github.com/brimdata/build-zeek/files/14910151/repro2.pcap.gz).

```
$ cat repro2.pcap | ~/Downloads/zeek-fdea29d/zeek/zeekrunner -

$ zq -Z '*SSL*' notice.log 
{
    _path: "notice",
    ts: 2015-03-11T09:38:43.633846Z,
    uid: "Cy06cy2L5swZ1l7Ryl",
    id: {
        orig_h: 192.168.0.51,
        orig_p: 48543 (port=uint16),
        resp_h: 2.22.42.85,
        resp_p: 443 (port)
    },
    fuid: "Fw3yYj47FjADHwdzhj",
    file_mime_type: null (string),
    file_desc: null (string),
    proto: "tcp" (=zenum),
    note: "SSL::Invalid_Server_Cert" (zenum),
    msg: "SSL certificate validation failed with (unable to get local issuer certificate)",
    sub: "CN=www.paypalobjects.com,OU=CDN Support,O=PayPal\\, Inc.,L=San Jose,ST=California,C=US",
    src: 192.168.0.51,
    dst: 2.22.42.85,
    p: 443 (port),
    n: null (uint64),
    peer_descr: null (string),
    actions: |[
        "Notice::ACTION_LOG" (zenum),
        "Notice::ACTION_ADD_GEODATA" (zenum)
    ]|,
    email_dest: |[]| (|[string]|),
    suppress_for: 1h,
    remote_location: {
        country_code: "SE",
        region: "AB",
        city: "Liljeholmen",
        latitude: 59.3199,
        longitude: 18.0123
    }
}
```

Closes #10