### PR TITLE
Restore single quotes around 'EOF'

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,7 @@ $sudo pip3 install btest wheel
 install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
-$sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek << EOF
+$sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek << 'EOF'
 @load policy/protocols/conn/community-id-logging
 @load policy/protocols/ssl/ssl-log-ext
 

--- a/release.sh
+++ b/release.sh
@@ -73,6 +73,7 @@ $sudo pip3 install btest wheel
 install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
+
 $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek << 'EOF'
 @load policy/protocols/conn/community-id-logging
 @load policy/protocols/ssl/ssl-log-ext


### PR DESCRIPTION
I made a mistake while merging two recent PRs. #14 needed these single quotes around `'EOF'` to allow the `$` in some Zeek script code to make its way into the output, whereas #13 did not need that treatment. There was a merge conflict between the two, so when resolving that I accidentally took the variant without the single quotes, so I caught my mistake when verifying the final changes on tip of `main`. Fixing that here.