### PR TITLE
Point to newer geoip-conn that has the latest data and also now includes ASNs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -70,7 +70,7 @@ install_zeek_package() {
 
 $sudo pip3 install btest wheel
 
-install_zeek_package brimdata/geoip-conn c9dd7f0f8d40573189b2ed2bae9fad478743cfdf
+install_zeek_package brimdata/geoip-conn 47d53a11921f4932b3076fee5fc50493b108764f
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
 echo "@load policy/protocols/conn/community-id-logging" | $sudo tee -a /usr/local/zeek/share/zeek/site/local.zeek


### PR DESCRIPTION
Now that https://github.com/brimdata/geoip-conn/pull/48 has merged to support ASNs and https://github.com/brimdata/geoip-conn/pull/49 has merged to include the ASN databases in the geop-conn Zeek packages, this PR advances the pointer to start using that more recent geoip-conn in our Zeek artifacts such that the ASN data will be included for pcaps processed by Brimcap/Zui going forward. Here's an example of it doing its thing using an artifact from [this Actions run](https://github.com/brimdata/build-zeek/actions/runs/8725798991) that was build using commit 559e2f5 from this branch.

```
$ cat ~/pcap/wrccdc.pcap | ./zeekrunner -

$ zq -Z 'geo.resp.as_number != null | head 1' conn.log 
{
    _path: "conn",
    ts: 2018-03-23T19:58:23.222228Z,
    uid: "C4qVti4oLGTPsUvcGk",
    id: {
        orig_h: 10.47.2.155,
        orig_p: 52821 (port=uint16),
        resp_h: 172.217.11.78,
        resp_p: 443 (port)
    },
    proto: "tcp" (=zenum),
    service: null (string),
    duration: 1.468ms,
    orig_bytes: 31 (uint64),
    resp_bytes: 0 (uint64),
    conn_state: "SF",
    local_orig: true,
    local_resp: false,
    missed_bytes: 0 (uint64),
    history: "DTFfA",
    orig_pkts: 6 (uint64),
    orig_ip_bytes: 374 (uint64),
    resp_pkts: 2 (uint64),
    resp_ip_bytes: 104 (uint64),
    tunnel_parents: null (|[string]|),
    geo: {
        orig: {
            country_code: null (string),
            region: null (string),
            city: null (string),
            latitude: null (float64),
            longitude: null (float64),
            as_number: null (uint64),
            as_org: null (string)
        },
        resp: {
            country_code: "US",
            region: null (string),
            city: null (string),
            latitude: 37.751,
            longitude: -97.822,
            as_number: 15169 (uint64),
            as_org: "GOOGLE"
        }
    },
    community_id: "1:V0dJfyHPUpu2ANb/x4OSlXp9QdA="
}
```
