### PR TITLE
Build from Zeek v7.0.0 and use latest GeoIP database

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: zeek/zeek
-        ref: v6.2.0
+        ref: v7.0.0
         fetch-depth: 1
         submodules: recursive
         path: zeek-src

--- a/release.sh
+++ b/release.sh
@@ -70,7 +70,7 @@ install_zeek_package() {
 
 $sudo pip3 install btest wheel
 
-install_zeek_package brimdata/geoip-conn 4be3eb91a556c91659953f27495b0ab52dae9219
+install_zeek_package brimdata/geoip-conn aba34d6b9e87d7e21a895f2513d809b4dfcf804d
 install_zeek_package salesforce/hassh 76a47abe9382109ce9ba530e7f1d7014a4a95209
 install_zeek_package salesforce/ja3 421dd4f3616b533e6971bb700289c6bb8355e707
 


### PR DESCRIPTION
Zeek [v7.0.0](https://github.com/zeek/zeek/releases/tag/v7.0.0) came out recently, so here I'm building that version for inclusion with Brimcap/Zui. I took the opportunity to update the GeoIP database while I was at it. I smoke tested a build artifact that came out of an Actions run of this branch and it seemed to work fine.

There's a companion PR https://github.com/brimdata/zed/pull/5212 that brings us current to Zeek v7.0.0 with the reference shaper as well.